### PR TITLE
Replacelibupower

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,25 @@ then add the following to your configuration:
 
 #### Battery format variables:
 
- - `state`
- - `level`
- - `temperature`
- - `is_fully_charged` (Check section "Conditional Variable" for usage)
- - `is_charging`
+ - `name`
+ - `present`
+ - `technology`
+ - `model_name`
+ - `manufacturer`
+ - `serial_number`
+ - `status`
+ - `cycle_count`
+ - `voltage_min_design`
+ - `voltage_now`
+ - `charge_full_design`
+ - `charge_full`
+ - `charge_now`
+ - `capacity`
+ - `capacity_level`
+ - `is_charging`        (Check section "Conditional Variable" for usage)
  - `is_discharging`
- - `is_empty`
+ - `is_not_charging`
+ - `is_full`
 
 #### Memory Usage variables:
 
@@ -168,6 +180,8 @@ Conditional variables are used to selectively print strings.
 
 For example, setting "format" in "battery" to "{is_charging:Charging}" will print "Charging" only
 when the battery is charging.
+
+All variables start with "is" and "has" are conditional variables.
 
 #### Recursive Conditional Variable:
 

--- a/example-config.json
+++ b/example-config.json
@@ -1,7 +1,7 @@
 {
     "battery": {
         "format":
-            "{is_fully_charged:Battery is Full}{is_charging:charging {level}%}{is_discharging: discharging {level}%}"
+            "{is_full:Battery is Full}{is_charging:charging {capacity}%}{is_discharging:discharging {capacity}%}"
     },
     "memory_usage": {
         "format": "<Mem> Free {MemFree}/Total {MemTotal} <Swap> Free {SwapFree}/{SwapTotal}"

--- a/src/print_battery.cc
+++ b/src/print_battery.cc
@@ -1,53 +1,186 @@
+#define _DEFAULT_SOURCE /* For macro constants of struct dirent::d_type and struct timespec */
+#ifndef  _GNU_SOURCE
+# define _GNU_SOURCE     /* For strchrnul */
+#endif
+
 #include <stddef.h>
 #include <string.h>
 #include <assert.h>
 #include <err.h>
-#include <upower.h>
 
+#include <sys/types.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <fcntl.h>     /* For O_RDONLY */
+#include <unistd.h>    /* For close, lseek and fstat */
+
+#include <string_view>
+
+#include "utility.h"
 #include "printer.hpp"
 #include "Conditional.hpp"
+#include "LazyEval.hpp"
 #include "print_battery.h"
 
 using swaystatus::Conditional;
+using swaystatus::LazyEval;
+
+static const char * const path = "/sys/class/power_supply/";
 
 static const char *format;
-static UpClient *client;
+
+/**
+ * If battery not found, battery_device is left unchanged, which by default is NULL
+ *
+ * Since having multiple batteries for laptop/desktop/workstation doesn't make much sense,
+ * swaystatus now only supports single battery device.
+ */
+static const char *battery_device;
+static int uevent_fd;
+
+static char *buffer;
+static size_t buffer_sz;
 
 extern "C" {
+int add_battery(int path_fd, const char *device)
+{
+    battery_device = strdup_checked(device);
+
+    size_t device_name_len = strlen(battery_device);
+    char relative_path[device_name_len + 1 + sizeof("uevent")];
+
+    memcpy(relative_path, device, device_name_len);
+    relative_path[device_name_len] = '/';
+    memcpy(relative_path + device_name_len + 1, "type", sizeof("type"));
+
+    int fd = openat_checked(path, path_fd, relative_path, O_RDONLY);
+
+    char type[sizeof("Battery")];
+    ssize_t bytes = readall(fd, type, sizeof(type) - 1);
+    if (bytes < 0)
+        err(1, "%s on %s%s failed", "readall", path, buffer);
+    if (bytes == 0)
+        errx(1, "%s on %s%s failed", "Assumption", path, buffer);
+    type[bytes] = '\0';
+
+    close(fd);
+
+    if (strncmp("Battery", type, sizeof("Battery") - 1) != 0)
+        return 0;
+
+    memcpy(relative_path + device_name_len + 1, "uevent", sizeof("uevent"));
+    uevent_fd = openat_checked(path, path_fd, relative_path, O_RDONLY);
+
+    return 1;
+}
 void init_battery_monitor(const char *format_str)
 {
     format = format_str;
 
-    GError *error = NULL;
-    client = up_client_new_full(NULL, &error);
-    if (client == NULL)
-        errx(1, "%s failed: %s", "up_client_new", error->message);
+    DIR *dir = opendir(path);
+    if (!dir)
+        err(1, "%s on %s failed", "opendir", path);
+
+    const int path_fd = dirfd(dir);
+
+    errno = 0;
+    for (struct dirent *ent; (ent = readdir(dir)); errno = 0) {
+        switch (ent->d_type) {
+            case DT_UNKNOWN:
+            case DT_LNK:
+                if (!isdir(path, path_fd, ent->d_name))
+                    break;
+
+            case DT_DIR:
+                if (strcmp(ent->d_name, ".") != 0 && strcmp(ent->d_name, "..") != 0) {
+                    if (add_battery(path_fd, ent->d_name))
+                        goto done;
+                }
+
+            default:
+                break;
+        }
+    }
+
+    if (errno != 0)
+        err(1, "%s on %s failed", "readdir", path);
+
+done:
+    closedir(dir);
+}
+
+static void read_battery_uevent()
+{
+    ssize_t cnt = asreadall(uevent_fd, &buffer, &buffer_sz);
+    if (cnt < 0)
+        err(1, "%s on %s%s/%s failed", "read", path, battery_device, "uevent");
+
+    if (lseek(uevent_fd, 0, SEEK_SET) == (off_t) -1)
+        err(1, "%s on %s failed", "lseek", path);
+}
+
+static auto get_property(std::string_view name) -> std::string_view
+{
+    char *substr = strcasestr(buffer, name.data());
+    if (!substr)
+        return "nullptr";
+
+    const char *value = substr + name.size() + 1;
+    const char *end = strchrnul(substr, '\n');
+
+    return {value, static_cast<std::size_t>(end - value)};
+}
+static auto get_property_lazy(std::string_view name) noexcept
+{
+    return LazyEval{[=]() noexcept
+    {
+        return get_property(name);
+    }};
+}
+static auto get_conditional_lazy(std::string_view name, std::string_view val) noexcept
+{
+    return LazyEval{[=]() noexcept
+    {
+        return Conditional{get_property(name) == val};
+    }};
 }
 
 void print_battery()
 {
-    UpDevice *device = up_client_get_display_device(client);
-
-    UpDeviceState state;
-    gdouble percentage;
-    gdouble temperature;
-    g_object_get(device, 
-        "state", &state,
-        "percentage", &percentage,
-        "temperature", &temperature,
-    NULL);
+    read_battery_uevent();
 
     swaystatus::print(
         format,
-        fmt::arg("state", up_device_state_to_string(state)),
-        fmt::arg("level", static_cast<unsigned>(percentage)),
-        fmt::arg("temperature", temperature),
-        fmt::arg("is_fully_charged", Conditional{state == UP_DEVICE_STATE_FULLY_CHARGED}),
-        fmt::arg("is_discharging",   Conditional{state == UP_DEVICE_STATE_DISCHARGING}),
-        fmt::arg("is_charging",      Conditional{state == UP_DEVICE_STATE_CHARGING}),
-        fmt::arg("is_empty",         Conditional{state == UP_DEVICE_STATE_EMPTY})
-    );
+        fmt::arg("type", "battery"),
 
-    g_object_unref(device);
+#define ARG(literal) fmt::arg((literal), get_property_lazy(literal))
+        ARG("name"),
+        ARG("present"),
+        ARG("technology"),
+
+        ARG("model_name"),
+        ARG("manufacturer"),
+        ARG("serial_number"),
+
+        ARG("status"),
+
+        ARG("cycle_count"),
+
+        ARG("voltage_min_design"),
+        ARG("voltage_now"),
+
+        ARG("charge_full_design"),
+        ARG("charge_full"),
+        ARG("charge_now"),
+
+        ARG("capacity"),
+        ARG("capacity_level"),
+#undef ARG
+
+        fmt::arg("is_charging", get_conditional_lazy("status", "Charging")),
+        fmt::arg("is_discharging", get_conditional_lazy("status", "Discharging")),
+        fmt::arg("is_not_charging", get_conditional_lazy("status", "Not charging")),
+        fmt::arg("is_full", get_conditional_lazy("status", "Full"))
+    );
 }
 }

--- a/src/print_memory_usage.cc
+++ b/src/print_memory_usage.cc
@@ -45,7 +45,10 @@ void init_memory_usage_collection(const char *format_str)
 
 static void read_meminfo()
 {
-    asreadall(meminfo_fd, &buffer, &buffer_sz);
+    ssize_t cnt = asreadall(meminfo_fd, &buffer, &buffer_sz);
+    if (cnt < 0)
+        err(1, "%s on %s failed", "read", "/proc/meminfo");
+
     if (lseek(meminfo_fd, 0, SEEK_SET) == (off_t) -1)
         err(1, "%s on %s failed", "lseek", "/proc/meminfo");
 }

--- a/src/swaystatus.c
+++ b/src/swaystatus.c
@@ -74,7 +74,7 @@ static uintmax_t parse_cmdline_arg_and_initialize(
     if (features->time)
         init_time(get_format(config, "time", "%Y-%m-%d %T"));
     if (features->battery)
-        init_battery_monitor(get_format(config, "battery", "{state} {level}%"));
+        init_battery_monitor(get_format(config, "battery", "{status} {capacity}%"));
     if (features->volume)
         init_volume_monitor(
             get_format(config, "volume", "vol {volume}%"),

--- a/src/utility.c
+++ b/src/utility.c
@@ -109,6 +109,13 @@ ssize_t asreadall(int fd, char **buffer, size_t *len)
             return -1;
     }
 
+    if (bytes == *len) {
+        *len += 1;
+        reallocarray_checked((void**) buffer, *len, sizeof(char));
+    }
+
+    (*buffer)[*len - 1] = '\0';
+
     return bytes;
 }
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -47,7 +47,8 @@ ssize_t readall(int fd, void *buffer, size_t len);
  * @param len must point to length of *buffer, can be 0
  * @return -1 if read failed, error code is stored in errno.
  *
- * If buffer isn't large enough, then asreadall will realloc it.
+ * If buffer isn't large enough, then asreadall will realloc it
+ * The read in buffer will be zero-terminated.
  */
 ssize_t asreadall(int fd, char **buffer, size_t *len);
 


### PR DESCRIPTION
Replace use of `libupower` with reading from `/sys/class/power_supply/<bat>/uevent` since it has the following advantages:
 -  no talking to upowerd over dbus, which simply probe `/sys/class/power_supply`
 - doesn't have to create a new gobject each time print_battery is called
 - can retrieve lots of statistic information easily, with a simple to understand API compared to glib

This PR also fixed unchecked use of `asreadalll` in `print_memory_usage`.

 The internal API `asreadall` now null-terminates `*buffer`.