### PR TITLE
poller are implemented

### DIFF
--- a/src/poller.c
+++ b/src/poller.c
@@ -1,0 +1,90 @@
+#include <poll.h>
+
+#include <err.h>
+#include <errno.h>
+
+#include "utility.h"
+#include "poller.h"
+
+struct callback_storer {
+    poller_callback callback;
+    void *data;
+};
+
+static struct pollfd *fds;
+static nfds_t nfds;
+static struct callback_storer *callbacks;
+
+void init_poller()
+{}
+
+static short fromEvent(enum Event events)
+{
+    short result = 0;
+    if (events & read_ready)
+        result |= POLLIN;
+    return result;
+}
+static enum Event toEvent(short events)
+{
+    if (events & POLLNVAL)
+        return invalid_fd;
+
+    enum Event result = 0;
+
+    if (events & POLLIN)
+        result |= read_ready;
+    if (events & POLLERR)
+        result |= error;
+    if (events & POLLHUP)
+        result |= hup;
+
+    return result;
+}
+
+void request_polling(int fd, enum Event events, poller_callback callback, void *data)
+{
+    ++nfds;
+    reallocate(fds,       nfds);
+    reallocate(callbacks, nfds);
+
+    fds[nfds - 1] = (struct pollfd){
+        .fd = fd,
+        .events = fromEvent(events)
+    };
+    callbacks[nfds - 1] = (struct callback_storer){
+        .callback = callback,
+        .data = data
+    };
+}
+
+static nfds_t skip_empty_revents(nfds_t i)
+{
+    for (; fds[i].revents == 0; ++i)
+        ;
+    return i;
+}
+
+void perform_polling(int timeout)
+{
+    if (nfds == 0)
+        return;
+
+    int result = 0;
+    do {
+        result = poll(fds, nfds, timeout);
+    } while (result == -1 && errno == EINTR);
+    /* Use < 0 here to tell the compiler that in the loop below, result cannot be less than 0 */
+    if (result < 0)
+        err(1, "%s failed", "poll");
+
+    nfds_t i = 0;
+    for (int cnt = 0; cnt != result; ++cnt) {
+        i = skip_empty_revents(i);
+
+        struct callback_storer *storer = &callbacks[i];
+        storer->callback(fds[i].fd, toEvent(fds[i].revents), storer->data);
+
+        ++i;
+    }
+}

--- a/src/poller.h
+++ b/src/poller.h
@@ -1,0 +1,30 @@
+#ifndef  __swaystatus_poller_HPP__
+# define __swaystatus_poller_HPP__
+
+# ifdef __cplusplus
+extern "C" {
+# endif
+
+void init_poller();
+
+enum Event {
+    read_ready = 1 << 0,
+    /**
+     * error, hup and invalid_fd can be set in event for the poller_callback,
+     * no matter it is registed with it or not.
+     */
+    error      = 1 << 2,
+    hup        = 1 << 3,
+    invalid_fd = -1,
+};
+typedef void (*poller_callback)(int fd, enum Event events, void *data);
+
+void request_polling(int fd, enum Event events, poller_callback callback, void *data);
+
+void perform_polling(int timeout);
+
+# ifdef __cplusplus
+}
+# endif
+
+#endif

--- a/src/swaystatus.c
+++ b/src/swaystatus.c
@@ -22,6 +22,7 @@
 #include "printer.hpp"
 #include "process_configuration.h"
 
+#include "poller.h"
 #include "print_battery.h"
 #include "print_time.h"
 #include "print_volume.h"
@@ -70,6 +71,8 @@ static uintmax_t parse_cmdline_arg_and_initialize(
     }
 
     config2features(config, features);
+
+    init_poller();
 
     if (features->time)
         init_time(get_format(config, "time", "%Y-%m-%d %T"));
@@ -152,6 +155,8 @@ int main(int argc, char* argv[])
     flush();
 
     for (size_t sec = 0; ; msleep(interval), ++sec) {
+        perform_polling(0);
+
         print_literal_str("[");
 
         if (features.brightness) {


### PR DESCRIPTION
Add poller support to swaystatus, though currently no `print_*` function utilizes it.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>