### PR TITLE
Fix garbage output in print_network_interface

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,7 @@ ifneq ($(shell python3 -c 'import sys; print(sys.version_info >= (3, 7))'), True
 	$(error Minimum python3 version is 3.7)
 endif
 
-	CFLAGS += $(shell python3-config --cflags) -DUSE_PYTHON
+	CFLAGS += $(shell python3-config --includes) -DUSE_PYTHON
 	LIBS += $(shell python3-config --ldflags --embed)
 endif
 


### PR DESCRIPTION
Caused by `CFLAGS += $(shell python3-config --cflags)`, which adds

```
-Wno-unused-result -Wsign-compare -Wunreachable-code -march=native
-fmerge-all-constants -fwrapv -DNDEBUG
```

along with `-I/usr/include/python3.8 -I/usr/include/python3.8` to my
CFLAGS and caused print_network_interface to output garbage.

The flags that cause this problem might be `-fmerge-all-constants` or
`-fwrapv`, which may have suprising side effect on my code.

Anyway, it is fixed now by replacing `python3-config --cflags` with
`python3-config --includes`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>