### PR TITLE
Refactor process_configuration: Move add_click_event_handler to print…

### DIFF
--- a/src/handle_click_events.cc
+++ b/src/handle_click_events.cc
@@ -70,6 +70,9 @@ void init_click_events_handling()
 
 void add_click_event_handler(const char *name, const void *click_event_handler_config)
 {
+    if (click_event_handler_config == NULL)
+        return;
+
     auto &callback = callbacks[callback_cnt++];
 
     callback.name = name;

--- a/src/handle_click_events.h
+++ b/src/handle_click_events.h
@@ -9,6 +9,9 @@ extern "C" {
 
 void init_click_events_handling();
 
+/**
+ * @param click_event_handler_config if equals to NULL, return without doing anything.
+ */
 void add_click_event_handler(const char *name, const void *click_event_handler_config);
 
 # ifdef __cplusplus

--- a/src/print_battery.cc
+++ b/src/print_battery.cc
@@ -21,6 +21,7 @@
 
 #include "utility.h"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "Battery.hpp"
 #include "print_battery.h"
@@ -28,6 +29,8 @@
 using swaystatus::Battery;
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "battery";
 
 static const char *user_specified_properties_str;
 
@@ -51,6 +54,8 @@ void init_battery_monitor(void *config)
     interval = get_update_interval(config, "battery", 3);
 
     const char *excluded_model = get_property(config, "excluded_model", "");
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(
         config,
@@ -116,7 +121,7 @@ void print_battery()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("battery");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_brightness.cc
+++ b/src/print_brightness.cc
@@ -16,6 +16,7 @@
 
 #include "utility.h"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "Conditional.hpp"
 #include "print_brightness.h"
@@ -23,6 +24,8 @@
 using swaystatus::Conditional;
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "brightness";
 
 static const char * const path = "/sys/class/backlight/";
 
@@ -94,6 +97,8 @@ void init_brightness_detection(void *config)
     short_text_format = get_short_format(config, NULL);
 
     interval = get_update_interval(config, "brightness", 1);
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(config);
 
@@ -180,7 +185,7 @@ void print_brightness()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("brightness");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_load.cc
+++ b/src/print_load.cc
@@ -11,11 +11,14 @@
 
 #include "utility.h"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "print_load.h"
 
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "load";
 
 static const char * const loadavg_path = "/proc/loadavg";
 
@@ -44,6 +47,8 @@ void init_load(void *config)
     );
     short_text_format = get_short_format(config, NULL);
     interval = get_update_interval(config, "load", 60);
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(config);
 
@@ -121,7 +126,7 @@ void print_load()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("load");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_memory_usage.cc
+++ b/src/print_memory_usage.cc
@@ -15,6 +15,7 @@
 
 #include "utility.h"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "mem_size_t.hpp"
 #include "LazyEval.hpp"
@@ -24,6 +25,8 @@ using namespace std::literals;
 using swaystatus::mem_size_t;
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "memory_usage";
 
 static int meminfo_fd;
 
@@ -50,6 +53,8 @@ void init_memory_usage_collection(void *config)
     short_text_format = get_short_format(config, NULL);
 
     interval = get_update_interval(config, "memory_usage", 10);
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(config);
 
@@ -145,7 +150,7 @@ void print_memory_usage()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("memory_usage");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_network_interfaces.cc
+++ b/src/print_network_interfaces.cc
@@ -7,6 +7,7 @@
 #include <exception>
 
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "Conditional.hpp"
 #include "networking.hpp"
@@ -17,6 +18,8 @@ using swaystatus::interface_stats;
 using swaystatus::Interfaces;
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "network_interfaces";
 
 static const char *user_specified_properties_str;
 
@@ -91,6 +94,8 @@ void init_network_interfaces_scanning(void *config)
     );
     interval = get_update_interval(config, "network_interface", 60 * 2);
 
+    add_click_event_handler(module_name, get_click_event_handler(config));
+
     user_specified_properties_str = get_user_specified_property_str(config);
 
     getifaddrs_checked();
@@ -122,7 +127,7 @@ void print_network_interfaces()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("network_interfaces");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_sensors.cc
+++ b/src/print_sensors.cc
@@ -3,12 +3,15 @@
 
 #include "sensors.hpp"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "print_sensors.h"
 
 using swaystatus::Sensors;
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "sensors";
 
 static const char *user_specified_properties_str;
 
@@ -30,6 +33,8 @@ void init_sensors(void *config)
     );
     short_text_format = get_short_format(config, NULL);
     interval = get_update_interval(config, "sensors", 5);
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(config);
 
@@ -76,7 +81,7 @@ void print_sensors()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("sensors");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/print_time.c
+++ b/src/print_time.c
@@ -7,8 +7,11 @@
 #include <unistd.h>
 
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "print_time.h"
+
+static const char * const module_name = "time";
 
 static const char *user_specified_properties_str;
 
@@ -19,6 +22,8 @@ void init_time(void *config)
 {
     full_text_format = get_format(config, "%Y-%m-%d %T");
     short_text_format = get_short_format(config, NULL);
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str_impl(config, 0);
 }
@@ -61,7 +66,7 @@ void print_time()
         errx(1, "localtime_r failed due to time(NULL) has failed");
 
     print_literal_str("{\"name\":\"");
-    print_str("time");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt(&local_time, "full_text", full_text_format);

--- a/src/print_volume.cc
+++ b/src/print_volume.cc
@@ -3,11 +3,14 @@
 
 #include "alsa.h"
 #include "process_configuration.h"
+#include "handle_click_events.h"
 #include "printer.hpp"
 #include "print_volume.h"
 
 using swaystatus::print;
 using swaystatus::get_user_specified_property_str;
+
+static const char * const module_name = "volume";
 
 static uint32_t cycle_cnt;
 static uint32_t interval;
@@ -29,6 +32,8 @@ void init_volume_monitor(void *config)
         get_property(config, "mix_name", "Master"),
         get_property(config, "card",     "default")
     );
+
+    add_click_event_handler(module_name, get_click_event_handler(config));
 
     user_specified_properties_str = get_user_specified_property_str(config, "mix_name", "card");
 }
@@ -53,7 +58,7 @@ void print_volume()
     }
 
     print_literal_str("{\"name\":\"");
-    print_str("volume");
+    print_str(module_name);
     print_literal_str("\",\"instance\":\"0\",");
 
     print_fmt("full_text", full_text_format);

--- a/src/process_configuration.c
+++ b/src/process_configuration.c
@@ -174,6 +174,7 @@ const char* get_user_specified_property_str_impl(void *module_config, unsigned n
 
     json_object_object_del(module_config, "format");
     json_object_object_del(module_config, "update_interval");
+    json_object_object_del(module_config, "click_event_handler");
     for (unsigned i = 0; i != n; ++i) {
         json_object_object_del(module_config, va_arg(ap, const char*));
     }
@@ -208,6 +209,13 @@ const char* get_user_specified_property_str_impl(void *module_config, unsigned n
 
     return ret;
 }
+const void* get_click_event_handler(const void *module_config)
+{
+    struct json_object *click_event_handler;
+    if (!json_object_object_get_ex(module_config, "click_event_handler", &click_event_handler))
+        return NULL;
+    return click_event_handler;
+}
 
 static bool is_block_printer_enabled(const void *config, const char *name)
 {
@@ -237,6 +245,8 @@ static void get_default_order(const void *config, struct Inits *inits)
 }
 void parse_inits_config(void *config, struct Inits *inits)
 {
+    init_click_events_handling();
+
     if (config == NULL)
         return get_default_order(config, inits);
 
@@ -259,30 +269,6 @@ void parse_inits_config(void *config, struct Inits *inits)
     inits->order[out] = NULL;
 
     json_object_object_del(config, "order");
-}
-
-int init_click_event_handlers(void *config, const char *names[9], int force_enabled)
-{
-    init_click_events_handling();
-
-    if (!config)
-        return 1;
-
-    for (size_t i = 0; names[i]; ++i) {
-        const char *name = names[i];
-
-        struct json_object *block;
-        if (!json_object_object_get_ex(config, name, &block))
-            continue;
-
-        struct json_object *click_event_handler;
-        if (!json_object_object_get_ex(block, "click_event_handler", &click_event_handler))
-            continue;
-
-        add_click_event_handler(name, click_event_handler);
-    }
-
-    return 1;
 }
 
 void get_block_printers(const char * const order[9], struct Blocks *blocks)

--- a/src/process_configuration.h
+++ b/src/process_configuration.h
@@ -25,7 +25,7 @@ void* get_module_config(void *config, const char *name);
 void free_config(void *config);
 
 /**
- * The 4 getters below are used in 'print_*.cc' only
+ * The 5 getters below are used in 'print_*.cc' only
  */
 
 /**
@@ -41,6 +41,8 @@ const char* get_short_format(const void *module_config, const char *default_val)
  * @param module_name used only for printing err msg
  */
 uint32_t get_update_interval(const void *module_config, const char *module_name, uint32_t default_val);
+
+const void* get_click_event_handler(const void *module_config);
 
 /**
  * @param n number of variadic args
@@ -75,14 +77,10 @@ struct Inits {
 };
 /**
  * @param config after this function is invoked, element 'order' is removed.
+ *
+ * This function also calls init_click_events_handling().
  */
 void parse_inits_config(void *config, struct Inits *inits);
-
-/**
- * @param config after this function, elements '*.click_event_handler' is removed.
- * @return whether click events handling is enabled.
- */
-int init_click_event_handlers(void *config, const char *names[9], int force_enabled);
 
 typedef void (*Printer_t)();
 /**

--- a/src/swaystatus.c
+++ b/src/swaystatus.c
@@ -43,7 +43,7 @@ static void handle_reload_request(int sig)
 
 static uintmax_t parse_cmdline_arg_and_initialize(
     int argc, char* argv[],
-    bool *is_reload, bool *is_click_event_enabled, const char **config_filename,
+    bool *is_reload, const char **config_filename,
     struct Blocks *blocks
 )
 {
@@ -95,8 +95,6 @@ static uintmax_t parse_cmdline_arg_and_initialize(
 
     for (size_t i = 0; inits.inits[i]; ++i)
         inits.inits[i](get_module_config(config, inits.order[i]));
-
-    *is_click_event_enabled = init_click_event_handlers(config, inits.order, *is_reload);
 
     get_block_printers(inits.order, blocks);
 
@@ -151,12 +149,11 @@ int main(int argc, char* argv[])
     struct Blocks blocks;
 
     bool is_reload = false;
-    bool is_click_event_enabled;
     const char *config_filename = NULL;
 
     const uintmax_t interval = parse_cmdline_arg_and_initialize(
         argc, argv,
-        &is_reload, &is_click_event_enabled, &config_filename,
+        &is_reload, &config_filename,
         &blocks
     );
 
@@ -165,12 +162,7 @@ int main(int argc, char* argv[])
 
     if (!is_reload) {
         /* Print header */
-        print_literal_str("{\"version\":1");
-
-        if (is_click_event_enabled)
-            print_literal_str(",\"click_events\":true");
-
-        print_literal_str("}\n");
+        print_literal_str("{\"version\":1,\"click_events\":true}\n");
 
         flush();
 


### PR DESCRIPTION
Decouple `process_configuration.h` and `handle_click_event.h`.

Each `print` module should be well aware of the presence of `click_event_handler` and in the future these handler might be able to 
affect the module via return value.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>