### PR TITLE
Speedup "initial load time"

### DIFF
--- a/src/utility.h
+++ b/src/utility.h
@@ -52,6 +52,8 @@ void msleep(uintmax_t msec);
  * @param msec milliseconds
  * @return a pollable fd. 
  *
+ * The initial expire of the timer is ASAP (1 ns)
+ *
  * Check man page of timefd_create for how to use the return value of this API.
  */
 int create_pollable_monotonic_timer(uintmax_t msec);


### PR DESCRIPTION
The "initial load time" of the `swaystatus` is caused by the initial expiration time of `create_pollable_monotonic_timer` is set to
`interval`, which is 1 sec by default.

This PR resolves that by setting the initial expire of the timer to be ASAP

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>